### PR TITLE
Updated elgohr/Github-Release-Action to a supported version (v4)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,7 +36,7 @@ jobs:
         python manage.py test
     - uses: actions/checkout@master
     - name: Create a Release
-      uses: elgohr/Github-Release-Action@master
+      uses: elgohr/Github-Release-Action@v4
       env:
         GITHUB_TOKEN: ${{ secrets.TOKEN }}
       with:


### PR DESCRIPTION
elgohr/Github-Release-Action@master is not supported anymore